### PR TITLE
Date of… meeting notes posting, or of meeting?

### DIFF
--- a/docs/psc.json
+++ b/docs/psc.json
@@ -77,7 +77,7 @@
    },
    {
       "subj" : "PSC #14 minutes, 2021-03-02",
-      "date" : "2021-04-04",
+      "date" : "2021-04-02",
       "url" : "https://www.nntp.perl.org/group/perl.perl5.porters/2021/04/msg259700.html",
       "num" : "014"
    },


### PR DESCRIPTION
I’m just submitting this patch as a basis for discussion.

Right now as far as I can see the dates listed are the dates on which the meeting notes were posted. This isn’t always the date on which the meeting took place. Which date do you intend to show?

I wouldn’t mind doing the remaining data cleaning to make it the date on which the meeting took place, but that’d be a lot of work to waste if that’s not what you want.