### PR TITLE
Fix sorting

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,7 +60,7 @@
                 Meeting Date
                 <i class="bi-arrow-down-up sort-icon"></i>
               </th>
-              <th data-sortable="true" data-sort-order="asc" onclick="sortTable(1)">
+              <th data-sortable="true" data-sort-order="asc" onclick="sortTable(2)">
                 Publication Date
                 <i class="bi-arrow-down-up sort-icon"></i>
               </th>

--- a/docs/js/code.js
+++ b/docs/js/code.js
@@ -23,6 +23,12 @@ function createTable(data) {
   });
 }
 
+function compareRows(a, b, columnIndex) {
+    const aText = a.cells[columnIndex].textContent.trim();
+    const bText = b.cells[columnIndex].textContent.trim();
+    return aText.localeCompare(bText, undefined, { numeric: true, sensitivity: 'base' });
+}
+
 function sortTable(columnIndex) {
   const table = document.getElementById('jsonTable');
   const columnHeader = table.getElementsByTagName('th')[columnIndex];
@@ -48,10 +54,7 @@ function sortTable(columnIndex) {
   const tbody = table.tBodies[0];
   const rows = Array.from(tbody.rows);
   const sortedRows = rows.sort((a, b) => {
-    const aText = a.cells[columnIndex].textContent.trim();
-    const bText = b.cells[columnIndex].textContent.trim();
-    const comparison = aText.localeCompare(bText, undefined, { numeric: true, sensitivity: 'base' });
-
+    const comparison = compareRows(a, b, columnIndex) || compareRows(a, b, 1); // date_meet tiebreak
     return sortOrder === 'asc' ? comparison : -comparison;
   });
 


### PR DESCRIPTION
Due to a trivial oversight, sorting by publication date doesn’t work: clicking the sort buttons sorts by meeting date instead. The first patch fixes that.

Also, the sort order for the \#65 meetings comes out wrong: the second \#65 (by date) is shown when the first \#65 should be shown. And with sorting by publication date enabled by the first patch, the ordering of the \#45 \#46 \#47 \#48 \#49 meetings becomes ambiguous when sorted by publication date, because they were all summarised in a single posting and therefore share the same publication date. The one piece of data which never compares equal between two PSC meetings is the date on which they took place, so the second patch adds a fallback to the meeting date as a tie breaker in the sorting.